### PR TITLE
docs: opacity는 reflow가 발생 안 한다구요...? 정말??

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 
 - [카카오웹툰은 CSS를 어떻게 작성하고 있을까? - kakao](https://fe-developers.kakaoent.com/2022/220210-css-in-kakaowebtoon/)
 - [CSS Triggers](https://blinders.tistory.com/92)
+- [opacity는 reflow가 발생 안 한다구요...? 정말??](https://blinders.tistory.com/93) 
 
 ### CS
 


### PR DESCRIPTION
### 저자 혹은 출처 

<!-- 글을 작성한 저자나 작성된 공간을 명시해주세요. -->

### 내용

- opacity는 크롬의 렌더링 엔진(blink)에서는 reflow가 발생하지 않는다고 되어 있다.
    - 하지만 performance 탭을 통해 기록을 보면 reflow가 발생하는 것을 확인할 수 있다.
    - opacity를 `1`이 아닌 `0.99` 등으로 설정하게 되면 reflow는 발생하지 않는다.
- opacity라는 스타일 변경은 렌더링 단계의 reflow부터 발생하기도 하지만 **때로는** repaint, composite부터 발생하기도 한다.
    - 그렇다면 reflow를 발생시키는 조건은 뭘까?
    - 렌더링 과정에서 레이어가 도입되는 이유는 z축을 활용하는 3차원 개념을 렌더링 과정에 삽입하기 위해서다. (쌓임 맥락 : HTML 요소들을 사용자 기준으로 Z축으로 세우기 위해 적용된 것, z-index)
    - 즉 레이어는 쌓임 맥락을 위한 층으로 활용되는 것이다. 이 레이어 중 GPU가 처리해야 하는 층이 있다면 이는 Graphics Layer다.
- 레이어(Paint Layer)가 쌓이기 위한 조건은?
    - 보통 레이어는 1개로 구성되며 CPU가 렌더링 역할을 한다. 레이어가 한 개라는 것은 z값이 동일한 공간에 있는 것
    - [쌓임 맥락](https://developer.mozilla.org/ko/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context#%EC%8C%93%EC%9E%84_%EB%A7%A5%EB%9D%BD)을 발생시키는 여러 trigger가 있는데 이를 통해 여러 레이어를 쌓을 수 있다.
    - 이 중 `opacity가 1보다 작은 요소`라는 조건이 있는데, opacity를 1보다 작게 설정하면 **별도의** 레이어를 구성시킨다. (즉, 쌓임 맥락을 triggers)
    - 즉, 별도의 Paint Layer를 구성하지 않은 오브젝트들은 reflow를 발생시킬 수 있다.
- Graphics Layer를 Triggers하는 조건은? (링크 참조)
    - Graphics Layers는 렌더링을 위해 GPU의 도움을 얻는 층이다.
    - GPU의 도움을 받으면 좋은 점은 CPU의 연산을 나눠서 함께 할 수 있다.

> 요소의 스타일 특정값을 주어 변경시켰을 때 이 부분이 Paint Layer에 들어가는지, Graphics Layer에 들어가는지 명확한 확인이 필요하다.
> 

### 감상

`opacity: 1`이 예상과는 달리 reflow를 일으킨다는 점은 알고 있었지만, 이유에 대해 정확히 알지 못했다. 그저 `z-index`와 관련됐을 것이라고 생각한 쌓임 맥락이 렌더링에서 등장하다니

### 링크

https://blinders.tistory.com/93

<!-- 아티클의 주소를 작성해주세요. -->

<!-- 감사합니다 🙂 -->  
