### PR TITLE
docs: 역사로 알아보는 CSS가 어려워진 이유

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 - [카카오웹툰은 CSS를 어떻게 작성하고 있을까? - kakao](https://fe-developers.kakaoent.com/2022/220210-css-in-kakaowebtoon/)
 - [CSS Triggers](https://blinders.tistory.com/92)
 - [opacity는 reflow가 발생 안 한다구요...? 정말??](https://blinders.tistory.com/93) 
+- [역사로 알아보는 CSS가 어려워진 이유 1편](https://yozm.wishket.com/magazine/detail/1319/)
+- [역사로 알아보는 CSS가 어려워진 이유 2편](https://yozm.wishket.com/magazine/detail/1326/)
 
 ### CS
 


### PR DESCRIPTION
### 저자 혹은 출처 

<!-- 글을 작성한 저자나 작성된 공간을 명시해주세요. -->

### 내용 

CSS가 어려워진 이유를 역사를 통해 알아볼 수 있다! 
너무 재밌으므로 매우 추천한다. 
CSS in JS가 큰 점유율을 차지하게 된 이유는 여러 역사가 존재한다. 
이를 알아보면 쉽게 CSS in JS를 왜 쓰는지 알 수 있다. 

<!-- 아티클의 내용을 간단하게 적어주세요. -->

### 감상 

<!-- 해당 아티클을 읽은 후 느낀점을 작성해주세요. (선택) -->

### 링크

https://yozm.wishket.com/magazine/detail/1319/
https://yozm.wishket.com/magazine/detail/1326/

<!-- 아티클의 주소를 작성해주세요. -->

<!-- 감사합니다 🙂 -->  
